### PR TITLE
fix: deadlinks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@
 ## Playwright with Browserbase
 Browserbase is the best developer platform to reliably run, manage, and monitor headless browsers.
 
-Get browsers' full control and leverage Browserbase's
-[Infrastructure](https://docs.browserbase.com/under-the-hood), [Stealth Mode](https://docs.browserbase.com/features/stealth-mode), and
-[Session Debugger](https://docs.browserbase.com/features/sessions) to power your automation, test suites,
-and LLM data retrievals.
+Get browsers' full control and leverage Browserbase's Infrastructure, Stealth Mode, and Session Debugger to power your automation, test suites, and LLM data retrievals.
 
 **Get started in under one minute** with Playwright.
 
@@ -54,6 +51,5 @@ npm start
 
 ## Further reading
 
-- [See how to leverage the Session Debugger for faster development](https://docs.browserbase.com/guides/browser-remote-control#accelerate-your-local-development-with-remote-debugging)
-- [Learn more about Browserbase infrastructure](https://docs.browserbase.com/under-the-hood)
-- [Explore the Sessions API](https://docs.browserbase.com/api-reference/list-all-sessions)
+- [See how to leverage the Session Debugger for faster development](https://docs.browserbase.com/fundamentals/manage-browser-session#debugging-completed-sessions)
+- [Explore the Sessions API](https://docs.browserbase.com/reference/api/create-a-session)


### PR DESCRIPTION
# what 

Some of the links in the README were linking to docs that didn't exist anymore. Removing the ones that don't exist and rerouting to the current versions. 